### PR TITLE
Disable Cobra mousetrap

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,9 +7,12 @@ package main
 
 import (
 	"github.com/rgravlin/noitabackup/pkg/cmd"
+	"github.com/spf13/cobra"
 )
 
 func main() {
+	// disable the mousetrap
+	cobra.MousetrapHelpText = ""
 	cmd.Execute()
 }
 


### PR DESCRIPTION
Prevents Cobra from stopping the application from starting when launched from Explorer in Windows.